### PR TITLE
Fix scraper parsing and cache handling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,9 +10,9 @@ This is a Rust web scraper service deployed on Cloudflare Workers that monitors 
 
 The application consists of two main modules:
 - `src/lib.rs`: Cloudflare Worker entry point with fetch event handler and routing
-- `src/client.rs`: Web scraping logic using scraper crate to parse HTML and extract version information
+- `src/client.rs`: Web scraping logic that parses version sections, validates release dates, and normalizes download URLs
 
-The scraper targets specific selectors (`strong > a` for links, `td > p > strong` for version text) and parses French month names to ISO date format. Uses the workers-rs crate for HTTP requests and error handling.
+The scraper splits the page into `<h2>` sections, extracts version text and downloadable `.zip`, `.exe`, or `.msi` links, and parses French month names to ISO date format. It uses the workers-rs crate for HTTP requests and error handling.
 
 ## Prerequisites
 
@@ -35,8 +35,8 @@ npm install -g wrangler
 # Install worker-build and run locally
 wrangler dev
 
-# Build for production
-wrangler build
+# Validate the production build without deploying
+wrangler deploy --dry-run
 ```
 
 ### Code Quality
@@ -74,11 +74,13 @@ Configuration is managed via `wrangler.toml`. The worker compiles to WebAssembly
 
 - `GET /`: Returns JSON with current DSN tool version info
   ```json
-  {
-    "version": "build_number",
-    "date": "YYYY-MM-DD",
-    "url": "download_link"
-  }
+  [
+    {
+      "version": "build_number",
+      "date": "YYYY-MM-DD",
+      "urls": ["download_link"]
+    }
+  ]
   ```
 
 The worker automatically handles HTTPS and runs globally on Cloudflare's edge network.

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,16 +1,24 @@
 use regex::Regex;
 use serde::Serialize;
+use std::collections::HashSet;
 use std::sync::LazyLock;
 use worker::*;
 
 const URL: &str = "https://www.net-entreprises.fr/declaration/outils-de-controle-dsn-val/";
 
 static VERSION_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"Version\s+([\d.]+)\s+du\s+(\d{1,2})\s+([\p{L}]+)\s+(\d{4})").unwrap()
+    Regex::new(
+        r"(?i)Version\s+(\d+(?:\.\d+)*)\s+du\s+(\d{1,2})(?:\s+(?:er|e))?\s+([\p{L}]+)\s+(\d{4})",
+    )
+    .unwrap()
 });
 
-static DOWNLOAD_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r#"href=["']([^"']*\.(?:zip|exe|msi))["']"#).unwrap());
+static HTML_TAG_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?s)<[^>]+>").unwrap());
+
+static SECTION_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?i)<h2\b[^>]*>").unwrap());
+
+static HREF_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"(?i)href\s*=\s*["']([^"']+)["']"#).unwrap());
 
 #[derive(Debug, PartialEq, Eq, Serialize)]
 pub struct DsnToolInfo {
@@ -19,36 +27,63 @@ pub struct DsnToolInfo {
     urls: Vec<String>,
 }
 
-fn month_to_number(month: &str) -> Option<&'static str> {
+fn month_to_number(month: &str) -> Option<u32> {
     match month.trim().to_lowercase().as_str() {
-        "janvier" => Some("01"),
-        "février" | "fevrier" => Some("02"),
-        "mars" => Some("03"),
-        "avril" => Some("04"),
-        "mai" => Some("05"),
-        "juin" => Some("06"),
-        "juillet" => Some("07"),
-        "août" | "aout" => Some("08"),
-        "septembre" => Some("09"),
-        "octobre" => Some("10"),
-        "novembre" => Some("11"),
-        "décembre" | "decembre" => Some("12"),
+        "janvier" => Some(1),
+        "février" | "fevrier" => Some(2),
+        "mars" => Some(3),
+        "avril" => Some(4),
+        "mai" => Some(5),
+        "juin" => Some(6),
+        "juillet" => Some(7),
+        "août" | "aout" => Some(8),
+        "septembre" => Some(9),
+        "octobre" => Some(10),
+        "novembre" => Some(11),
+        "décembre" | "decembre" => Some(12),
         _ => None,
     }
 }
 
-fn normalize_download_url(url: &str) -> Option<String> {
-    Url::parse(URL)
-        .ok()?
-        .join(url)
-        .ok()
-        .map(|url| url.to_string())
+fn is_valid_date(year: u32, month: u32, day: u32) -> bool {
+    let is_leap_year =
+        year.is_multiple_of(4) && (!year.is_multiple_of(100) || year.is_multiple_of(400));
+    let days_in_month = match month {
+        2 if is_leap_year => 29,
+        2 => 28,
+        4 | 6 | 9 | 11 => 30,
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        _ => return false,
+    };
+
+    (1..=days_in_month).contains(&day)
+}
+
+fn normalize_download_url(raw_url: &str) -> Option<Url> {
+    let decoded_url = raw_url
+        .trim()
+        .replace("&amp;", "&")
+        .replace("&#038;", "&")
+        .replace("&#38;", "&")
+        .replace("&#x26;", "&")
+        .replace("&#X26;", "&");
+    let url = Url::parse(URL).ok()?.join(&decoded_url).ok()?;
+
+    matches!(url.scheme(), "http" | "https").then_some(url)
+}
+
+fn is_download_url(url: &Url) -> bool {
+    url.path()
+        .rsplit_once('.')
+        .map(|(_, extension)| extension.to_ascii_lowercase())
+        .is_some_and(|extension| matches!(extension.as_str(), "zip" | "exe" | "msi"))
 }
 
 fn extract_download_urls(section: &str) -> Vec<String> {
     let mut urls = Vec::new();
+    let mut seen = HashSet::new();
 
-    for capture in DOWNLOAD_RE.captures_iter(section) {
+    for capture in HREF_RE.captures_iter(section) {
         let Some(raw_url) = capture.get(1).map(|m| m.as_str()) else {
             continue;
         };
@@ -57,7 +92,12 @@ fn extract_download_urls(section: &str) -> Vec<String> {
             continue;
         };
 
-        if !urls.contains(&url) {
+        if !is_download_url(&url) {
+            continue;
+        }
+
+        let url = url.to_string();
+        if seen.insert(url.clone()) {
             urls.push(url);
         }
     }
@@ -66,11 +106,16 @@ fn extract_download_urls(section: &str) -> Vec<String> {
 }
 
 fn parse_section(section: &str) -> Option<DsnToolInfo> {
-    let version_caps = VERSION_RE.captures(section)?;
+    let text = HTML_TAG_RE.replace_all(section, " ");
+    let version_caps = VERSION_RE.captures(&text)?;
     let build = version_caps.get(1)?.as_str();
     let day: u32 = version_caps.get(2)?.as_str().parse().ok()?;
     let month = month_to_number(version_caps.get(3)?.as_str())?;
-    let year = version_caps.get(4)?.as_str();
+    let year: u32 = version_caps.get(4)?.as_str().parse().ok()?;
+
+    if !is_valid_date(year, month, day) {
+        return None;
+    }
 
     let urls = extract_download_urls(section);
     if urls.is_empty() {
@@ -79,9 +124,13 @@ fn parse_section(section: &str) -> Option<DsnToolInfo> {
 
     Some(DsnToolInfo {
         version: build.to_string(),
-        date: format!("{}-{}-{:02}", year, month, day),
+        date: format!("{year:04}-{month:02}-{day:02}"),
         urls,
     })
+}
+
+fn parse_page(body: &str) -> Vec<DsnToolInfo> {
+    SECTION_RE.split(body).filter_map(parse_section).collect()
 }
 
 pub async fn get_info() -> worker::Result<Vec<DsnToolInfo>> {
@@ -99,7 +148,7 @@ pub async fn get_info() -> worker::Result<Vec<DsnToolInfo>> {
     }
 
     let body = response.text().await?;
-    let results: Vec<DsnToolInfo> = body.split("<h2").filter_map(parse_section).collect();
+    let results = parse_page(&body);
 
     if results.is_empty() {
         return Err(worker::Error::RustError(
@@ -141,16 +190,49 @@ mod tests {
     fn parse_section_supports_single_quoted_links_and_deduplicates_urls() {
         let section = r#"
             <h2>Version 2025.2 du 14 Fevrier 2025</h2>
-            <a href='https://cdn.example.com/dsn-val.msi'>Msi</a>
-            <a href='https://cdn.example.com/dsn-val.msi'>Duplicate</a>
+            <a href='https://cdn.example.com/dsn-val.MSI?mirror=1&amp;source=api'>Msi</a>
+            <a href='https://cdn.example.com/dsn-val.MSI?mirror=1&amp;source=api'>Duplicate</a>
         "#;
 
         let info = parse_section(section).unwrap();
 
         assert_eq!(
             info.urls,
-            vec!["https://cdn.example.com/dsn-val.msi".to_string()]
+            vec!["https://cdn.example.com/dsn-val.MSI?mirror=1&source=api".to_string()]
         );
         assert_eq!(info.date, "2025-02-14");
+    }
+
+    #[test]
+    fn parse_page_handles_ordinal_date_markup() {
+        let page = r#"
+            <h2>Outil Dsn-Val 2026</h2>
+            <p><strong>Version 2026.1.0.15 du 25 juin 2026</strong></p>
+            <a href="https://cdn.example.com/dsn-val-2026.zip">Download</a>
+            <h2 class="title">Outil Dsn-Val 2027</h2>
+            <p><strong>Version 2027.1.0.2 du 1<sup>er</sup> juillet 2026</strong></p>
+            <a href="https://cdn.example.com/dsn-val-2027.exe">Download</a>
+        "#;
+
+        let info = parse_page(page);
+
+        assert_eq!(info.len(), 2);
+        assert_eq!(info[1].version, "2027.1.0.2");
+        assert_eq!(info[1].date, "2026-07-01");
+    }
+
+    #[test]
+    fn parse_section_rejects_invalid_dates_and_non_http_downloads() {
+        let invalid_date = r#"
+            Version 2025.1 du 31 février 2025
+            <a href="https://cdn.example.com/dsn-val.zip">Download</a>
+        "#;
+        let invalid_scheme = r#"
+            Version 2025.1 du 28 février 2025
+            <a href="javascript:dsn-val.zip">Download</a>
+        "#;
+
+        assert_eq!(parse_section(invalid_date), None);
+        assert_eq!(parse_section(invalid_scheme), None);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,39 +5,67 @@ mod client;
 const CACHE_TTL: u64 = 300; // 5 minutes
 
 #[event(fetch)]
-pub async fn main(req: Request, env: Env, _ctx: worker::Context) -> Result<Response> {
+pub async fn main(req: Request, env: Env, ctx: worker::Context) -> Result<Response> {
     console_error_panic_hook::set_once();
 
-    Router::new()
-        .get_async("/", |req, _ctx| async move {
-            let cache = Cache::default();
-            let cache_request = Request::new_with_init(
-                req.url()?.as_str(),
-                RequestInit::new().with_method(Method::Get),
-            )?;
-
-            // Try to get from cache first
-            if let Ok(Some(cached_response)) = cache.get(&cache_request, false).await {
-                return Ok(cached_response);
-            }
-
-            // Cache miss - fetch fresh data
-            match client::get_info().await {
-                Ok(info) => {
-                    let mut response = Response::from_json(&info)?;
-
-                    // Set cache headers
-                    let headers = response.headers_mut();
-                    headers.set("Cache-Control", &format!("public, max-age={}", CACHE_TTL))?;
-
-                    // Store in cache
-                    let _ = cache.put(&cache_request, response.cloned()?).await;
-
-                    Ok(response)
-                }
-                Err(e) => Response::error(format!("Error: {}", e), 500),
-            }
-        })
+    Router::with_data(ctx)
+        .get_async("/", handle_root)
         .run(req, env)
         .await
+}
+
+async fn handle_root(req: Request, route: RouteContext<worker::Context>) -> Result<Response> {
+    let cache = Cache::default();
+    let cache_request = create_cache_request(&req)?;
+
+    match cache.get(&cache_request, false).await {
+        Ok(Some(cached_response)) => return Ok(cached_response),
+        Ok(None) => {}
+        Err(error) => console_error!("Cache lookup failed: {error}"),
+    }
+
+    match client::get_info().await {
+        Ok(info) => {
+            let mut response = Response::from_json(&info)?;
+            response
+                .headers_mut()
+                .set("Cache-Control", &format!("public, max-age={CACHE_TTL}"))?;
+
+            let cache_response = response.cloned()?;
+            route.data.wait_until(async move {
+                if let Err(error) = cache.put(&cache_request, cache_response).await {
+                    console_error!("Cache update failed: {error}");
+                }
+            });
+
+            Ok(response)
+        }
+        Err(error) => {
+            console_error!("DSN tool retrieval failed: {error}");
+            Response::error("Failed to retrieve DSN tool information", 502)
+        }
+    }
+}
+
+fn create_cache_request(req: &Request) -> Result<Request> {
+    let cache_url = canonical_cache_url(req.url()?);
+    Request::new_with_init(&cache_url, RequestInit::new().with_method(Method::Get))
+}
+
+fn canonical_cache_url(mut url: Url) -> String {
+    url.set_query(None);
+    url.set_fragment(None);
+    url.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cache_url_ignores_unused_query_and_fragment() {
+        let url = Url::parse("https://api.example.com/?cache-bust=1#result").unwrap();
+
+        assert_eq!(canonical_cache_url(url), "https://api.example.com/");
+    }
 }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,6 +1,6 @@
 name = "net-entreprise-scraper"
 main = "build/worker/shim.mjs"
-compatibility_date = "2023-05-18"
+compatibility_date = "2026-07-17"
 preview_urls = false
 
 [build]


### PR DESCRIPTION
## Summary

- parse DSN release sections through inline HTML markup, including French ordinal dates such as `1<sup>er</sup> juillet`
- validate calendar dates and normalize, filter, and deduplicate download URLs
- canonicalize cache keys and move cache writes to `waitUntil`
- log cache/upstream failures and return an appropriate 502 response
- refresh the Worker compatibility date and correct the repository documentation

## Root cause

The upstream page places the ordinal suffix in a `<sup>` element. The previous version regex expected the day and month to be adjacent text, so it silently skipped the entire 2027 release while still returning a non-empty response containing 2026.

## Impact

The API now returns both current release sections from the live Net-Entreprises page. Cache-busting query parameters also reuse the canonical cached response, and cache population no longer delays the response.

## Validation

- `cargo fmt --check`
- `cargo test` (5 tests)
- `cargo check --target wasm32-unknown-unknown`
- `cargo clippy --target wasm32-unknown-unknown -- -D warnings`
- local Wrangler request against the real upstream page returned both 2026 and 2027 releases
- query-string request returned `CF-Cache-Status: HIT`
- `wrangler deploy --dry-run` with Wrangler 4.112.0