### PR TITLE
Add regression tests and automated Worker deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,74 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test and build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+          targets: wasm32-unknown-unknown
+
+      - name: Cache Rust dependencies and tools
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: worker
+          add-job-id-key: "false"
+
+      - name: Check formatting
+        run: cargo fmt --all --check
+
+      - name: Run tests
+        run: cargo test --locked
+
+      - name: Run Clippy for the Worker target
+        run: cargo clippy --locked --target wasm32-unknown-unknown -- -D warnings
+
+      - name: Validate production Worker
+        uses: cloudflare/wrangler-action@v4
+        with:
+          command: deploy --dry-run
+
+  deploy:
+    name: Deploy Worker
+    needs: test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Restore Rust dependencies and tools
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: worker
+          add-job-id-key: "false"
+
+      - name: Deploy Worker
+        uses: cloudflare/wrangler-action@v4
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          command: deploy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,6 +318,7 @@ dependencies = [
  "console_error_panic_hook",
  "regex",
  "serde",
+ "serde_json",
  "worker",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,6 @@ worker = "0.8.5"
 serde = { version = "1.0", features = ["derive"] }
 console_error_panic_hook = "0.1.7"
 regex = "1.13.0"
+
+[dev-dependencies]
+serde_json = "1.0"

--- a/src/client.rs
+++ b/src/client.rs
@@ -222,6 +222,61 @@ mod tests {
     }
 
     #[test]
+    fn parse_page_keeps_downloads_within_their_version_section() {
+        let page = r#"
+            <h2>Incomplete version</h2>
+            <p>Version 2026.1 du 4 mars 2026</p>
+            <h2>Unrelated download</h2>
+            <a href="https://cdn.example.com/unrelated.zip">Download</a>
+            <h2>Complete version</h2>
+            <p>Version 2026.2 du 5 mars 2026</p>
+            <a href="https://cdn.example.com/dsn-val-2026.2.zip">Download</a>
+        "#;
+
+        let info = parse_page(page);
+
+        assert_eq!(info.len(), 1);
+        assert_eq!(info[0].version, "2026.2");
+        assert_eq!(
+            info[0].urls,
+            vec!["https://cdn.example.com/dsn-val-2026.2.zip"]
+        );
+    }
+
+    #[test]
+    fn parse_section_handles_leap_year_boundaries() {
+        let leap_day = r#"
+            Version 2024.2 du 29 février 2024
+            <a href="https://cdn.example.com/dsn-val.zip">Download</a>
+        "#;
+        let non_leap_day = r#"
+            Version 2100.2 du 29 février 2100
+            <a href="https://cdn.example.com/dsn-val.zip">Download</a>
+        "#;
+
+        assert_eq!(parse_section(leap_day).unwrap().date, "2024-02-29");
+        assert_eq!(parse_section(non_leap_day), None);
+    }
+
+    #[test]
+    fn dsn_tool_info_serializes_to_the_api_contract() {
+        let info = DsnToolInfo {
+            version: "2026.2".to_string(),
+            date: "2026-03-05".to_string(),
+            urls: vec!["https://cdn.example.com/dsn-val.zip".to_string()],
+        };
+
+        assert_eq!(
+            serde_json::to_value(info).unwrap(),
+            serde_json::json!({
+                "version": "2026.2",
+                "date": "2026-03-05",
+                "urls": ["https://cdn.example.com/dsn-val.zip"]
+            })
+        );
+    }
+
+    #[test]
     fn parse_section_rejects_invalid_dates_and_non_http_downloads() {
         let invalid_date = r#"
             Version 2025.1 du 31 février 2025

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,8 +64,12 @@ mod tests {
 
     #[test]
     fn cache_url_ignores_unused_query_and_fragment() {
-        let url = Url::parse("https://api.example.com/?cache-bust=1#result").unwrap();
+        let url =
+            Url::parse("https://api.example.com/releases/latest?cache-bust=1#result").unwrap();
 
-        assert_eq!(canonical_cache_url(url), "https://api.example.com/");
+        assert_eq!(
+            canonical_cache_url(url),
+            "https://api.example.com/releases/latest"
+        );
     }
 }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,4 +1,5 @@
 name = "net-entreprise-scraper"
+account_id = "c26e7cbc79e0d77767f00f5b29baa355"
 main = "build/worker/shim.mjs"
 compatibility_date = "2026-07-17"
 preview_urls = false

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,4 +4,4 @@ compatibility_date = "2026-07-17"
 preview_urls = false
 
 [build]
-command = "cargo install -q worker-build@0.8.5 && worker-build --release"
+command = "cargo install -q --locked worker-build@0.8.5 && worker-build --release"


### PR DESCRIPTION
## Summary

- add regression tests for scraper section isolation, leap-year dates, cache URL normalization, and the serialized API response contract
- add a cached Rust CI pipeline with formatting, tests, WASM Clippy, and a Wrangler deployment dry run
- deploy successful `main` builds through Wrangler Action using `CLOUDFLARE_API_TOKEN`
- keep `worker-build` pinned and lockfile-aware in `wrangler.toml`

## Why

Dependency updates need meaningful checks before they can be auto-merged safely. The workflow now validates both the parser/API behavior and the real Cloudflare Worker build path, then deploys only after the post-merge test job succeeds.

## Validation

- `cargo fmt --all --check`
- `cargo test --locked` (8 tests)
- `cargo clippy --locked --target wasm32-unknown-unknown -- -D warnings`
- `wrangler deploy --dry-run`
- `actionlint`
- YAML parsing and `git diff --check`
